### PR TITLE
patches from CrossOver 21.1.0 DXVK

### DIFF
--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -565,9 +565,12 @@ namespace dxvk {
     // order to avoid expensive synchronization with the GPU. This does
     // however require linear tiling, which may not be supported for all
     // combinations of image parameters.
-    return this->CheckImageSupport(pImageInfo, VK_IMAGE_TILING_LINEAR)
-      ? D3D11_COMMON_TEXTURE_MAP_MODE_DIRECT
-      : D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER;
+    // HACK: Never use direct mapping; it doesn't work right with MoltenVK
+    // because we don't unmap memory.
+    //return this->CheckImageSupport(pImageInfo, VK_IMAGE_TILING_LINEAR)
+    //  ? D3D11_COMMON_TEXTURE_MAP_MODE_DIRECT
+    //  : D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER;
+    return D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER;
   }
   
   

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -59,7 +59,18 @@ namespace dxvk {
       DxvkImageViewCreateInfo viewInfo;
       viewInfo.format  = formatInfo.Format;
       viewInfo.aspect  = formatInfo.Aspect;
-      viewInfo.swizzle = formatInfo.Swizzle;
+      // CrossOver bug 18050:
+      // Vulkan does not allow swizzled textures to be bound
+      // to VK_DESCRIPTOR_TYPE_STORAGE_IMAGE descriptors.
+      // In the particular case of MoltenVK, MTLPixelFormatA8Unorm
+      // textures (or the swizzled equivalent) are not writeable.
+      if (pDesc->Format != DXGI_FORMAT_A8_UNORM) {
+        if (formatInfo.Swizzle.r || formatInfo.Swizzle.g || formatInfo.Swizzle.b || formatInfo.Swizzle.a)
+          Logger::warn(str::format("Swizzled format in UAV: ", pDesc->Format));
+        viewInfo.swizzle = formatInfo.Swizzle;
+      } else {
+        Logger::info("Skipping DXGI_FORMAT_A8_UNORM swizzle for UAV");
+      }
       viewInfo.usage   = VK_IMAGE_USAGE_STORAGE_BIT;
       
       switch (pDesc->ViewDimension) {

--- a/src/dxbc/dxbc_chunk_isgn.cpp
+++ b/src/dxbc/dxbc_chunk_isgn.cpp
@@ -66,13 +66,22 @@ namespace dxvk {
   DxbcRegMask DxbcIsgn::regMask(
           uint32_t     registerId) const {
     DxbcRegMask mask;
+    DxbcRegMask svMask;
 
     for (auto e = this->begin(); e != this->end(); e++) {
-      if (e->registerId == registerId)
-        mask |= e->componentMask;
+      if (e->registerId == registerId) {
+        if (e->systemValue == DxbcSystemValue::None)
+          mask |= e->componentMask;
+        else
+          svMask |= e->componentMask;
+      }
     }
 
-    return mask;
+    if (mask != DxbcRegMask(0) && svMask != DxbcRegMask(0)) {
+      Logger::info("dxbc system value mask hack fired");
+    }
+
+    return mask != DxbcRegMask(0) ? mask : svMask;
   }
 
 

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -174,7 +174,9 @@ namespace dxvk {
       case VK_IMAGE_VIEW_TYPE_3D: {
         this->createView(VK_IMAGE_VIEW_TYPE_3D, 1);
         
-        if (m_image->info().flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT && m_info.numLevels == 1) {
+        if (m_image->info().flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT &&
+              info.usage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT|VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
+              info.numLevels == 1) {
           this->createView(VK_IMAGE_VIEW_TYPE_2D,       1);
           this->createView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, m_image->mipLevelExtent(m_info.minLevel).depth);
         }
@@ -227,8 +229,9 @@ namespace dxvk {
         "DxvkImageView: Failed to create image view:"
         "\n  View type:       ", viewInfo.viewType,
         "\n  View format:     ", viewInfo.format,
+        "\n  Usage:           ", std::hex, viewUsage.usage,
         "\n  Subresources:    ",
-        "\n    Aspect mask:   ", std::hex, viewInfo.subresourceRange.aspectMask,
+        "\n    Aspect mask:   ", viewInfo.subresourceRange.aspectMask, std::dec,
         "\n    Mip levels:    ", viewInfo.subresourceRange.baseMipLevel, " - ",
                                  viewInfo.subresourceRange.levelCount,
         "\n    Array layers:  ", viewInfo.subresourceRange.baseArrayLayer, " - ",
@@ -242,7 +245,7 @@ namespace dxvk {
         "\n    Mip levels:    ", m_image->info().mipLevels,
         "\n    Array layers:  ", m_image->info().numLayers,
         "\n    Samples:       ", m_image->info().sampleCount,
-        "\n    Usage:         ", std::hex, m_image->info().usage,
+        "\n    Usage:         ", std::hex, m_image->info().usage, std::dec,
         "\n    Tiling:        ", m_image->info().tiling));
     }
   }

--- a/src/dxvk/dxvk_state_cache.cpp
+++ b/src/dxvk/dxvk_state_cache.cpp
@@ -386,10 +386,10 @@ namespace dxvk {
   }
 
 
-  bool DxvkStateCache::readCacheFile() {
+  bool DxvkStateCache::realReadCacheFile(std::wstring name) {
     // Open state file and just fail if it doesn't exist
-    std::ifstream ifile(getCacheFileName().c_str(), std::ios_base::binary);
-
+    std::ifstream ifile(name.c_str(), std::ios_base::binary);
+    
     if (!ifile) {
       Logger::warn("DXVK: No state cache file found");
       return false;
@@ -470,6 +470,11 @@ namespace dxvk {
     
     // Rewrite entire state cache if it is outdated
     return curHeader.version == newHeader.version;
+  }
+
+  bool DxvkStateCache::readCacheFile() {
+    realReadCacheFile(getBaseCacheFileName());
+    return realReadCacheFile(getCacheFileName());
   }
 
 
@@ -993,6 +998,18 @@ namespace dxvk {
     
     std::string exeName = env::getExeBaseName();
     path += exeName + ".dxvk-cache";
+    return str::tows(path.c_str());
+  }
+
+
+  std::wstring DxvkStateCache::getBaseCacheFileName() const {
+    std::string path = getCacheDir();
+
+    if (!path.empty() && *path.rbegin() != '/')
+      path += '/';
+    
+    std::string exeName = env::getExeBaseName();
+    path += exeName + ".dxvk-cache-base";
     return str::tows(path.c_str());
   }
 

--- a/src/dxvk/dxvk_state_cache.h
+++ b/src/dxvk/dxvk_state_cache.h
@@ -142,6 +142,8 @@ namespace dxvk {
     void compilePipelines(
       const WorkerItem&               item);
 
+    bool realReadCacheFile(
+            std::wstring              name);
     bool readCacheFile();
 
     bool readCacheHeader(
@@ -182,6 +184,7 @@ namespace dxvk {
     void writerFunc();
 
     std::wstring getCacheFileName() const;
+    std::wstring getBaseCacheFileName() const;
     
     std::string getCacheDir() const;
 

--- a/src/vulkan/vulkan_presenter.cpp
+++ b/src/vulkan/vulkan_presenter.cpp
@@ -135,7 +135,15 @@ namespace dxvk::vk {
     // Select actual swap chain properties and create swap chain
     m_info.format       = pickFormat(formats.size(), formats.data(), desc.numFormats, desc.formats);
     m_info.presentMode  = pickPresentMode(modes.size(), modes.data(), desc.numPresentModes, desc.presentModes);
-    m_info.imageExtent  = pickImageExtent(caps, desc.imageExtent);
+    /* HACK: FFXIX wants to make sure that the client size of its window is at least 1024x720 and enforces that
+     * by increasing the size in WM_WINDOWPOSCHANGING. Unfortunately it adds the size of the window decorations
+     * in fullscreen mode even though the window does not have any decorations, causing an incorrect rendering
+     * size and mouse pointer offsets at low fullscreen resolutions.
+     *
+     * The game does the same thing on Windows and the bug can be reproduced in borderless windowed fullscreen
+     * mode if the desktop resolution is set to 1280x720. It seems that native d3d ignores the actual window
+     * size in real fullscreen mode. Try to do the same. */
+    m_info.imageExtent  = desc.imageExtent; //pickImageExtent(caps, desc.imageExtent);
     m_info.imageCount   = pickImageCount(caps, m_info.presentMode, desc.imageCount);
 
     if (!m_info.imageExtent.width || !m_info.imageExtent.height) {


### PR DESCRIPTION
Patches from DXVK 1.7 from CrossOver 21.1.0 rolled on top. [Source](https://media.codeweavers.com/pub/crossover/source/crossover-sources-21.1.0.tar.gz).

Makes Star Wars Jedi: Fallen Order and Borderlands 3 work with this build (graphical glitches still present, similar as with CrossOver's DXVK), and probably more titles too.